### PR TITLE
Updated isMDMEnrolled fact to use MunkiLooseVersion

### DIFF
--- a/facts/isMDMEnrolled.py
+++ b/facts/isMDMEnrolled.py
@@ -1,16 +1,18 @@
 import platform
 import plistlib
 import subprocess
-from distutils.version import LooseVersion
+import sys
+sys.path.insert(0, '/usr/local/munki')
+from munkilib.pkgutils import MunkiLooseVersion
 
 def get_os_version():
     '''Return OS version.'''
-    return LooseVersion(platform.mac_ver()[0])
+    return MunkiLooseVersion(platform.mac_ver()[0])
 
 def fact():
     '''Check MDM Enrollment Status'''
     # Check the OS and run our checks based on OS version
-    if get_os_version() >= LooseVersion('10.13.4'):
+    if get_os_version() >= MunkiLooseVersion('10.13.4'):
         # print 'Checking mdm status - modern'
         if check_mdm_status_modern():
             # print 'MDM enrolled device %s' % get_os_version()


### PR DESCRIPTION
When running the isMDMEnrolled.py munki-fact locally on a macOS endpoint it would fail.

```
/usr/local/munki/munki-python /usr/local/munki/conditions/facts/isMDMEnrolled.py
Traceback (most recent call last):
  File "/usr/local/munki/conditions/facts/isMDMEnrolled.py", line 4, in <module>
    from distutils.version import LooseVersion
ModuleNotFoundError: No module named 'distutils'
```
The error output above was generated when running the following version of munki-python.

```
/usr/local/munki/munki-python -V
Python 3.12.2
```
If I run the proposed modified version under munki-python version 3.12.2 the munki-fact runs and produces the desired output.

```
/usr/local/munki/munki-python /usr/local/munki/conditions/facts/isMDMEnrolled.py
{'isMDMEnrolled': True}
```

I believe that the changes that I've suggested will make it compatible with both the current and past versions of munki-python 3.x that is part of the latest munkitools releases. If I were to release newer versions of the munkitools client to my fleet, then this munki-fact would break and I would have no working condition.